### PR TITLE
Support for OpenSSL >= 1.1.0.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ esac
 # Checks for libraries.
 AC_CHECK_LIB(pcap, pcap_offline_filter, [],
              AC_MSG_ERROR(pcap library not found ))
-AC_CHECK_LIB(crypto, EVP_CIPHER_CTX_init, [],
+AC_CHECK_LIB(crypto, CRYPTO_new_ex_data, [],
              AC_MSG_ERROR(OpenSSL library not found))
 
 # Checks for header files.

--- a/src/esp.h
+++ b/src/esp.h
@@ -47,7 +47,7 @@ typedef struct auth_method_t {
 typedef struct llflow_t {
   address_t addr_src;
   address_t addr_dst;
-  EVP_CIPHER_CTX ctx;
+  EVP_CIPHER_CTX *ctx;
   unsigned char *key;
   u_int32_t spi;
   char *crypt_name;

--- a/src/ipdecap.c
+++ b/src/ipdecap.c
@@ -356,8 +356,8 @@ int add_flow(char *ip_src, char *ip_dst, char *crypt_name, char *auth_name, char
   flow->auth_name = strdup(auth_name);
   flow->key = dec_key;
 
-  EVP_CIPHER_CTX ctx;
-  EVP_CIPHER_CTX_init(&ctx);
+  EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+  EVP_CIPHER_CTX_init(ctx);
   flow->ctx = ctx;
 
   // Adding to linked list
@@ -543,7 +543,7 @@ void dump_flows() {
     printf("dump_flows: src:%s dst:%s crypt:%s auth:%s spi:%lx\n",
       src, dst, e->crypt_name, e->auth_name, (long unsigned int) e->spi);
 
-      dumpmem("key", e->key, EVP_CIPHER_CTX_key_length(&e->ctx), 0);
+      dumpmem("key", e->key, EVP_CIPHER_CTX_key_length(e->ctx), 0);
       printf("\n");
 
     e = e->next;
@@ -743,7 +743,7 @@ void process_esp_packet(u_char const *payload, const int payload_len, pcap_hdr *
   char ip_src[INET_ADDRSTRLEN+1];
   char ip_dst[INET_ADDRSTRLEN+1];
   llflow_t *flow = NULL;
-  EVP_CIPHER_CTX ctx;
+  EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
   const EVP_CIPHER *cipher = NULL;
   int packet_size, rc, len, remaining;
   int ivlen;
@@ -821,7 +821,7 @@ void process_esp_packet(u_char const *payload, const int payload_len, pcap_hdr *
     if ((cipher = EVP_get_cipherbyname(flow->crypt_method->openssl_cipher)) == NULL)
       error("Cannot find cipher %s - EVP_get_cipherbyname() err", flow->crypt_method->openssl_cipher);
 
-    EVP_CIPHER_CTX_init(&ctx);
+    EVP_CIPHER_CTX_init(ctx);
 
     // Copy initialization vector
     ivlen = EVP_CIPHER_iv_length(cipher);
@@ -829,7 +829,7 @@ void process_esp_packet(u_char const *payload, const int payload_len, pcap_hdr *
     memcpy(&esp_packet.iv, payload_src, ivlen);
     payload_src += ivlen;
 
-    rc = EVP_DecryptInit_ex(&ctx, cipher,NULL, flow->key, esp_packet.iv);
+    rc = EVP_DecryptInit_ex(ctx, cipher,NULL, flow->key, esp_packet.iv);
     if (rc != 1) {
       error("Error during the initialization of crypto system. Please report this bug with your .pcap file");
     }
@@ -847,7 +847,7 @@ void process_esp_packet(u_char const *payload, const int payload_len, pcap_hdr *
     }
 
     // Do the decryption work
-    rc = EVP_DecryptUpdate(&ctx, payload_dst, &len, payload_src, remaining);
+    rc = EVP_DecryptUpdate(ctx, payload_dst, &len, payload_src, remaining);
     packet_size += len;
 
     if (rc != 1) {
@@ -857,16 +857,16 @@ void process_esp_packet(u_char const *payload, const int payload_len, pcap_hdr *
         return;
     }
 
-    EVP_DecryptFinal_ex(&ctx, payload_dst+len, &len);
+    EVP_DecryptFinal_ex(ctx, payload_dst+len, &len);
     packet_size += len;
 
     // http://www.mail-archive.com/openssl-users@openssl.org/msg23434.html
-    packet_size +=EVP_CIPHER_CTX_block_size(&ctx);
+    packet_size +=EVP_CIPHER_CTX_block_size(ctx);
 
     u_char *pad_len = (new_packet_payload + packet_size -2);
 
     // Detect obviously badly decrypted packet
-    if (*pad_len >=  EVP_CIPHER_CTX_block_size(&ctx)) {
+    if (*pad_len >=  EVP_CIPHER_CTX_block_size(ctx)) {
       verbose("Warning: invalid pad_len field, wrong encryption key ? copying raw packet...\n");
       process_nonip_packet(payload, payload_len, new_packet_hdr, new_packet_payload);
       return;
@@ -880,7 +880,7 @@ void process_esp_packet(u_char const *payload, const int payload_len, pcap_hdr *
 
     new_packet_hdr->len = packet_size;
 
-    EVP_CIPHER_CTX_cleanup(&ctx);
+    EVP_CIPHER_CTX_cleanup(ctx);
 
     } /*  flow->crypt_method->openssl_cipher == NULL */
 


### PR DESCRIPTION
@lpefferkorn 

Hello Loïc,

This update shoud fix issue already reported here: https://github.com/lpefferkorn/ipdecap/issues/2
ipdecap still can be build against OpenSSL 1.0.x.
I have tested builds against:
- 1.1.0.g
- 1.0.2 (from OpenSSL GitHub repo, on branch OpenSSL_1_0_2-stable)